### PR TITLE
small enhancements to support repeated use

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.ms linguist-language=MiniScript

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 dist
 _local
+.DS_Store

--- a/example/main.ms
+++ b/example/main.ms
@@ -3,6 +3,12 @@ import "stringUtil"
 
 module.greet
 
+print "Here's a list:"
+print range(1,10)
+
+print "And here's a map:"
+print {"foo":"bar"}
+
 while true
   s = input("Name? ")
   if s == "quit" then exit

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "miniscript-web-term",
-  "version": "0.1.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "miniscript-web-term",
-      "version": "0.1.0",
+      "version": "0.2.1",
       "license": "MIT",
       "dependencies": {
         "@xterm/xterm": "^5.4.0-beta.1",

--- a/src/basicIO.ts
+++ b/src/basicIO.ts
@@ -1,6 +1,7 @@
 import { Runtime } from "miniscript-ts";
 import { Terminal } from "@xterm/xterm";
 import { Readline } from "xterm-readline";
+import { versionConfig } from "./version-config";
 
 export class BasicIO {
   
@@ -21,10 +22,10 @@ export class BasicIO {
     runtime.addIntrinsic('version',
     function(): any {
 		var result = runtime.newMap();
-		result.set("miniscript", "1.6.2");
-		result.set("buildDate", "1900-04-01");
-		result.set("hostName", "miniscript-tryit");
-		result.set("hostInfo", "https://github.com/JoeStrout/miniscript-tryit");
+		result.set("miniscript", versionConfig.miniscript);
+		result.set("buildDate", versionConfig.buildDate);
+		result.set("hostName", versionConfig.hostName);
+		result.set("hostInfo", versionConfig.hostInfo);
 		return result;
     });
   }

--- a/src/basicIO.ts
+++ b/src/basicIO.ts
@@ -13,33 +13,20 @@ export class BasicIO {
   addIntrinsics(runtime: Runtime) {
     const outerThis = this;
 
-    runtime.addIntrinsic('print(txt,delim=null)',
-    function(txt: string, delim: string | null) {
-      outerThis.print(txt, delim);
-    });
-
-    runtime.addIntrinsic('input(prompt=null)',
+	runtime.addIntrinsic('input(prompt=null)',
     function(prompt: string | null): Promise<string> {
       return outerThis.input(prompt);
     });
-  }
-
-  private print(txt: string, delim: string | null) {
-	console.log("print called with ", txt);
-    if (txt === undefined || txt === null) {
-      txt = "";
-	} else if (typeof txt !== "string") {
-	  console.log("Converting from ", typeof txt);
-	  txt = txt.toString();
-	}
-
-    if (delim !== null && delim !== "\n" && delim !== "\r") {
-      txt = txt + delim;
-      this.xterm.write(txt);
-    } else {
-      this.xterm.writeln(txt);
-    }
-
+    
+    runtime.addIntrinsic('version',
+    function(): any {
+		var result = runtime.newMap();
+		result.set("miniscript", "1.6.2");
+		result.set("buildDate", "1900-04-01");
+		result.set("hostName", "miniscript-tryit");
+		result.set("hostInfo", "https://github.com/JoeStrout/miniscript-tryit");
+		return result;
+    });
   }
 
   private async input(prompt: string | null): Promise<string> {

--- a/src/basicIO.ts
+++ b/src/basicIO.ts
@@ -25,10 +25,13 @@ export class BasicIO {
   }
 
   private print(txt: string, delim: string | null) {
-
+	console.log("print called with ", txt);
     if (txt === undefined || txt === null) {
       txt = "";
-    }
+	} else if (typeof txt !== "string") {
+	  console.log("Converting from ", typeof txt);
+	  txt = txt.toString();
+	}
 
     if (delim !== null && delim !== "\n" && delim !== "\r") {
       txt = txt + delim;

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,9 +28,14 @@ export async function runCodeFromString(sourceCode: string, fileSystem?:FileSyst
   }
 }
 
+export function abortCodeRun() {
+	if (msTerm) msTerm.abort = true;
+}
+
 // Export functions to the global scope
 window.runCodeFromPath = runCodeFromPath;
 window.runCodeFromString = runCodeFromString;
+window.abortCodeRun = abortCodeRun;
 
 addEventListener("DOMContentLoaded", async (_: Event) => {
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,20 +6,24 @@ declare global {
   interface Window { terminalOptions: TerminalOptions | undefined; }
 }
 
+let msTerm: MSTerminal | null = null;
+
 export async function runCodeFromPath(fileSystem, scriptFile) {
-  const msTerm = new MSTerminal(fileSystem, window.terminalOptions);
+  if (!msTerm) msTerm = new MSTerminal(fileSystem, window.terminalOptions);
   await msTerm.runCodeFromPath(scriptFile);
-  console.log("Finished");
 }
 
 export async function runCodeFromString(sourceCode: string, fileSystem?:FileSystem) {
-  console.log("Running code:\n" + sourceCode);
   if (!fileSystem) {
     fileSystem = new HttpFileSystem('', '');
   }
-  const msTerm = new MSTerminal(fileSystem, window.terminalOptions);
-  await msTerm.runCodeFromString(sourceCode);
-  console.log("Finished");
+  if (!msTerm) msTerm = new MSTerminal(fileSystem, window.terminalOptions);
+  try {
+	  await msTerm.runCodeFromString(sourceCode);
+  } catch (err) {
+	  console.log("error caught");
+  	  msTerm.terminal.writeln("Error found");
+  }
 }
 
 // Export functions to the global scope
@@ -39,8 +43,6 @@ addEventListener("DOMContentLoaded", async (_: Event) => {
 
   const [scriptBasePath, srcFile] = HttpFileSystem.splitPathAndFileName(fileName);
   const indexBasePath = new URL(document.baseURI).pathname.split("/").slice(0,-1).join("/");
-  console.log("Using script base-path:", scriptBasePath);
-  console.log("Using index base-path:", indexBasePath);
   const fileSystem = new HttpFileSystem(indexBasePath, scriptBasePath);
   
   runCodeFromPath(fileSystem, srcFile);

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ let msTerm: MSTerminal | null = null;
 
 export async function runCodeFromPath(fileSystem, scriptFile) {
   if (!msTerm) msTerm = new MSTerminal(fileSystem, window.terminalOptions);
+  window.xterm = msTerm.terminal;
   await msTerm.runCodeFromPath(scriptFile);
 }
 
@@ -18,12 +19,17 @@ export async function runCodeFromString(sourceCode: string, fileSystem?:FileSyst
     fileSystem = new HttpFileSystem('', '');
   }
   if (!msTerm) msTerm = new MSTerminal(fileSystem, window.terminalOptions);
+  window.xterm = msTerm.terminal;
   try {
 	  await msTerm.runCodeFromString(sourceCode);
   } catch (err) {
 	  console.log("error caught");
   	  msTerm.terminal.writeln("Error found");
   }
+}
+
+export function xterm() {
+	return msTerm.terminal;
 }
 
 // Export functions to the global scope

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,10 +28,6 @@ export async function runCodeFromString(sourceCode: string, fileSystem?:FileSyst
   }
 }
 
-export function xterm() {
-	return msTerm.terminal;
-}
-
 // Export functions to the global scope
 window.runCodeFromPath = runCodeFromPath;
 window.runCodeFromString = runCodeFromString;

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,12 +6,33 @@ declare global {
   interface Window { terminalOptions: TerminalOptions | undefined; }
 }
 
+export async function runCodeFromPath(fileSystem, scriptFile) {
+  const msTerm = new MSTerminal(fileSystem, window.terminalOptions);
+  await msTerm.runCodeFromPath(scriptFile);
+  console.log("Finished");
+}
+
+export async function runCodeFromString(sourceCode: string, fileSystem?:FileSystem) {
+  console.log("Running code:\n" + sourceCode);
+  if (!fileSystem) {
+    fileSystem = new HttpFileSystem('', '');
+  }
+  const msTerm = new MSTerminal(fileSystem, window.terminalOptions);
+  await msTerm.runCodeFromString(sourceCode);
+  console.log("Finished");
+}
+
+// Export functions to the global scope
+window.runCodeFromPath = runCodeFromPath;
+window.runCodeFromString = runCodeFromString;
+
 addEventListener("DOMContentLoaded", async (_: Event) => {
 
   const body = document.querySelector("body") as HTMLBodyElement;
   const fileName = body.getAttribute("data-src-file");
   if (typeof fileName !== "string") {
-    throw new Error("No source file specified!");
+    console.log("No source file specified on body tag");
+    return;
   }
 
   const terminalOptions = window.terminalOptions;
@@ -21,10 +42,7 @@ addEventListener("DOMContentLoaded", async (_: Event) => {
   console.log("Using script base-path:", scriptBasePath);
   console.log("Using index base-path:", indexBasePath);
   const fileSystem = new HttpFileSystem(indexBasePath, scriptBasePath);
-  const mainFile = srcFile;
-
-  const msTerm = new MSTerminal(fileSystem, terminalOptions);
-  await msTerm.runCode(mainFile);
-  console.log("Finished");
-
+  
+  runCodeFromPath(fileSystem, srcFile);
 });
+

--- a/src/msTerminal.ts
+++ b/src/msTerminal.ts
@@ -14,6 +14,7 @@ export class MSTerminal {
 
   interp: Interpreter;
   terminal: Terminal;
+  abort: boolean = false;
 
   constructor(private fileSystem: MSFileSystem, terminalOptions?: TerminalOptions) {
     const outCallback = (txt: string) => {
@@ -55,6 +56,7 @@ export class MSTerminal {
       const srcCode = await this.fileSystem.getSource(mainFile);
       const coopRunner = this.interp.getCooperativeRunner(srcCode, mainFile);
       if (coopRunner) {
+        this.abort = false;
         this.runCycles(coopRunner, (err) => {
           if (err) reject(err); else resolve();
         });
@@ -66,6 +68,7 @@ export class MSTerminal {
     return new Promise<void>(async (resolve) => {
 	  const coopRunner = this.interp.getCooperativeRunner(srcCode, null);
 	  if (coopRunner) {
+        this.abort = false;
 		this.runCycles(coopRunner, (err) => {
 		  if (err) reject(err); else resolve();
 		});
@@ -77,7 +80,7 @@ export class MSTerminal {
   }
 
   private runCycles(coopRunner: CooperativeRunner, onFinished: (err?: Error) => void) {
-    if (!coopRunner.isFinished()) {
+    if (!coopRunner.isFinished() && !this.abort) {
       try {
         coopRunner.runSomeCycles();
         setTimeout(() => { this.runCycles(coopRunner, onFinished); }, 0);

--- a/src/msTerminal.ts
+++ b/src/msTerminal.ts
@@ -48,9 +48,20 @@ export class MSTerminal {
     return [term, rl];
   }
 
-  async runCode(mainFile: string): Promise<void> {
+  async runCodeFromPath(mainFile: string): Promise<void> {
     return new Promise<void>(async (resolve) => {
       const srcCode = await this.fileSystem.getSource(mainFile);
+      const coopRunner = this.interp.getCooperativeRunner(srcCode, mainFile);
+      if (coopRunner) {
+        this.runCycles(coopRunner, () => {
+          resolve();
+        });
+      }
+    });
+  }
+
+  async runCodeFromString(srcCode: string): Promise<void> {
+    return new Promise<void>(async (resolve) => {
       const coopRunner = this.interp.getCooperativeRunner(srcCode, mainFile);
       if (coopRunner) {
         this.runCycles(coopRunner, () => {

--- a/src/msTerminal.ts
+++ b/src/msTerminal.ts
@@ -70,7 +70,7 @@ export class MSTerminal {
 		  if (err) reject(err); else resolve();
 		});
 	  } else {
-		console.logError("runCodeFromString: unable to get coopRunner");
+		//console.error("runCodeFromString: unable to get coopRunner");
 		reject(new Error("Unable to get coopRunner"));
 	  }
     });

--- a/src/version-config.ts
+++ b/src/version-config.ts
@@ -1,0 +1,6 @@
+export const versionConfig = {
+  miniscript: "1.6.2",
+  buildDate: "2024-06-24",
+  hostName: "miniscript-tryit",
+  hostInfo: "https://github.com/JoeStrout/miniscript-tryit"
+};


### PR DESCRIPTION
These changes are all about enabling it to be used in a context where the script may be supplied not just once when the page is loaded, but multiple times in response to events (such as a button click).  I need this for the new "try it!" page (https://github.com/JoeStrout/miniscript-tryit).

It also includes an attempt to fix the `print` function so that it works with values other than strings.  But this resulted in only partial success, as you can see in the attachment.
![image](https://github.com/sebnozzi/miniscript-web-term/assets/263365/e41aa834-a110-4c03-ad00-78fa35e4a0d4)

We really need some way to invoke whatever `str` does, from basicIO.ts.

But perhaps you can merge this PR, then fix that bug (if it's easy for you) and I'll pull your changes back down to my fork?